### PR TITLE
Ethiopian calendar support 2

### DIFF
--- a/date-carousel.js
+++ b/date-carousel.js
@@ -37,6 +37,8 @@ class DateCarousel extends LitElement {
 
     this.weekInView = now
     this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
+    this.weekUnixValue = now.toFormat('X') // unix timestamp in seconds
+    this.dateUnixValue = now.toFormat('X') // unix timestamp in seconds
     this._calculateDays()
   }
 
@@ -44,6 +46,7 @@ class DateCarousel extends LitElement {
     let days = []
     let currentDayCount = 1
     let currentDay = this.weekInView
+    this._monthYear = currentDay.toFormat('LLLL yyyy')
     while (currentDayCount <= 7) {
       days.push({
         dayOfWeek: currentDay.toFormat('ccc'),
@@ -51,23 +54,25 @@ class DateCarousel extends LitElement {
         day: currentDay.toFormat('dd'),
         month: currentDay.toFormat('LL'),
         year: currentDay.toFormat('yyyy'),
-        class: (this.datePicked === currentDay.toFormat(FORMAT_YEAR_MONTH_DAY)) ? 'selected' : ''
+        unix: currentDay.toFormat('X'),
+        class: (this.dateUnixValue === currentDay.toFormat('X')) ? 'selected' : ''
       })
       currentDay = currentDay.plus({days: 1})
       currentDayCount++
     }
     this._days = days
-    this._monthYear = currentDay.toFormat('LLLL yyyy')
   }
 
   _next() {
     this.weekInView = this.weekInView.plus({weeks: 1})
+    this.weekUnixValue = this.weekInView.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }
 
   _back() {
     this.weekInView = this.weekInView.minus({weeks: 1})
+    this.weekUnixValue = this.weekInView.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }
@@ -77,6 +82,7 @@ class DateCarousel extends LitElement {
     const month = event.currentTarget.dataset.month
     const year = event.currentTarget.dataset.year
     this.datePicked = `${year}-${month}-${day}`
+    this.dateUnixValue = event.currentTarget.dataset.unix
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-day-pick'))
   }
@@ -125,7 +131,7 @@ class DateCarousel extends LitElement {
             <mwc-icon class="back">chevron_left</mwc-icon>
           </td>
           ${this._days.map(day => html`
-            <td @click="${this._onDayPick}" data-day="${day.day}" data-month="${day.month}" data-year="${day.year}" class="clickable day ${day.class}">
+            <td @click="${this._onDayPick}" data-day="${day.day}" data-month="${day.month}" data-year="${day.year}" data-unix="${day.unix}" class="clickable day ${day.class}">
               <div class="day-of-week">
                 ${day.dayOfWeek}
               </div>

--- a/date-carousel.js
+++ b/date-carousel.js
@@ -66,6 +66,8 @@ class DateCarousel extends LitElement {
   _next() {
     this.weekInView = this.weekInView.plus({weeks: 1})
     this.weekUnixValue = this.weekInView.toFormat('X')
+    this.datePicked = this.weekInView
+    this.dateUnixValue = this.datePicked.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }
@@ -73,6 +75,8 @@ class DateCarousel extends LitElement {
   _back() {
     this.weekInView = this.weekInView.minus({weeks: 1})
     this.weekUnixValue = this.weekInView.toFormat('X')
+    this.datePicked = this.weekInView
+    this.dateUnixValue = this.datePicked.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }

--- a/date-carousel.js
+++ b/date-carousel.js
@@ -91,6 +91,20 @@ class DateCarousel extends LitElement {
     this.dispatchEvent(new CustomEvent('on-day-pick'))
   }
 
+  _today() {
+    var now = DateTime.local()
+    if (this.useEthiopianCalendar) {
+      now = now.reconfigure({ outputCalendar: 'ethiopic' })
+    }
+
+    this.weekInView = now
+    this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
+    this.weekUnixValue = now.toFormat('X')
+    this.dateUnixValue = now.toFormat('X')
+    this._calculateDays()
+    this.dispatchEvent(new CustomEvent('on-day-pick'))
+  }
+
   render() {
     return html`
       <style>
@@ -128,7 +142,16 @@ class DateCarousel extends LitElement {
           cursor: pointer;
         }
       </style>
-      <div class="month">${this._monthYear}</div>
+      <table class="header">
+        <tr>
+          <td>
+            <div class="month">${this._monthYear}</div>
+          </td>
+          <td class="clickable button" @click="${this._today}">
+            <button class="today">Today</button>
+          </td>
+        </tr>
+      </table>
       <table class="days">
         <tr>
           <td class="clickable button" @click="${this._back}">


### PR DESCRIPTION
Fixes and updates to the date carousel:
1. Provide the currently selected day and first day of the week value as a unix timestamp (to be consumed by the component's user)
2. Update the chosen day to the first day of the new week when the carousel moves forward or backward
3. Add a 'Today' button that resets the carousel to today's date