### PR TITLE
Ethiopian calendar support 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ import 'date-carousel/date-carousel.js'
 - `datePicked`: The ISO string (yyyy-mm-dd) of value of the currently selected day. 
 - `dateUnixValue`: The unix timestamp value in seconds of the currently selected day. 
 
+**NOTE**
+Unix timezone values do not contain timezone or daylight savings information. Use them wisely.
+
 ### Events
 - `on-day-picked`: When a user selects a day in the carousel, the attributes `datePicked` and `dateUnixValue` are updated and the event is dispatched.
 - `on-week-change`: When users move forward or back in the date carousel, the attributes `weekInView` and `weekUnixValue` are updated and the event is dispatched.

--- a/date-carousel.js
+++ b/date-carousel.js
@@ -36,8 +36,8 @@ class DateCarousel extends LitElement {
     }
 
     this.weekInView = now
-    this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
     this.weekUnixValue = now.toFormat('X') // unix timestamp in seconds
+    this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
     this.dateUnixValue = now.toFormat('X') // unix timestamp in seconds
     this._calculateDays()
   }
@@ -75,7 +75,7 @@ class DateCarousel extends LitElement {
         month: currentDay.toFormat('LL'),
         year: currentDay.toFormat('yyyy'),
         unix: currentDay.toFormat('X'),
-        class: (this.dateUnixValue === currentDay.toFormat('X')) ? 'selected' : ''
+        class: (this.datePicked === currentDay.toFormat(FORMAT_YEAR_MONTH_DAY)) ? 'selected' : ''
       })
       currentDay = currentDay.plus({days: 1})
       currentDayCount++
@@ -86,8 +86,8 @@ class DateCarousel extends LitElement {
   _next() {
     this.weekInView = this.weekInView.plus({weeks: 1})
     this.weekUnixValue = this.weekInView.toFormat('X')
-    this.datePicked = this.weekInView
-    this.dateUnixValue = this.datePicked.toFormat('X')
+    this.datePicked = this.weekInView.toFormat(FORMAT_YEAR_MONTH_DAY)
+    this.dateUnixValue = this.weekInView.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }
@@ -95,8 +95,8 @@ class DateCarousel extends LitElement {
   _back() {
     this.weekInView = this.weekInView.minus({weeks: 1})
     this.weekUnixValue = this.weekInView.toFormat('X')
-    this.datePicked = this.weekInView
-    this.dateUnixValue = this.datePicked.toFormat('X')
+    this.datePicked = this.weekInView.toFormat(FORMAT_YEAR_MONTH_DAY)
+    this.dateUnixValue = this.weekInView.toFormat('X')
     this._calculateDays()
     this.dispatchEvent(new CustomEvent('on-week-change'))
   }

--- a/date-carousel.js
+++ b/date-carousel.js
@@ -35,8 +35,8 @@ class DateCarousel extends LitElement {
       now = now.reconfigure({ outputCalendar: 'ethiopic' })
     }
 
-    this.weekInView = now
-    this.weekUnixValue = now.toFormat('X') // unix timestamp in seconds
+    this.weekInView = now.startOf("week")
+    this.weekUnixValue = now.startOf("week").toFormat('X') // unix timestamp in seconds
     this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
     this.dateUnixValue = now.toFormat('X') // unix timestamp in seconds
     this._calculateDays()
@@ -117,7 +117,7 @@ class DateCarousel extends LitElement {
       now = now.reconfigure({ outputCalendar: 'ethiopic' })
     }
 
-    this.weekInView = now
+    this.weekInView = now.startOf("week")
     this.datePicked = now.toFormat(FORMAT_YEAR_MONTH_DAY)
     this.weekUnixValue = now.toFormat('X')
     this.dateUnixValue = now.toFormat('X')

--- a/date-carousel.js
+++ b/date-carousel.js
@@ -42,11 +42,31 @@ class DateCarousel extends LitElement {
     this._calculateDays()
   }
 
+  _calculateHeaderText() {
+    let firstDayOfWeek = this.weekInView
+    let lastDayOfWeek = this.weekInView.plus({days: 6})
+
+    const firstDayOfWeekYear = parseInt(firstDayOfWeek.toFormat('yyyy'))
+    const lastDayOfWeekYear = parseInt(lastDayOfWeek.toFormat('yyyy'))
+
+    let headerText
+    if (firstDayOfWeekYear !== lastDayOfWeekYear) {
+      // the week stradles a new year --- show year text in both strings
+      headerText = `${firstDayOfWeek.toFormat('dd LLL yyyy')} - ${lastDayOfWeek.toFormat('dd LLL yyyy')}`
+    } else {
+      // the week is in the same year --- only show the year at the end
+      headerText = `${firstDayOfWeek.toFormat('dd LLL')} - ${lastDayOfWeek.toFormat('dd LLL yyyy')}`
+    }
+    return headerText
+  }
+
   _calculateDays() {
     let days = []
     let currentDayCount = 1
     let currentDay = this.weekInView
-    this._monthYear = currentDay.toFormat('LLLL yyyy')
+
+    this._headerText = this._calculateHeaderText()
+
     while (currentDayCount <= 7) {
       days.push({
         dayOfWeek: currentDay.toFormat('ccc'),
@@ -145,7 +165,7 @@ class DateCarousel extends LitElement {
       <table class="header">
         <tr>
           <td>
-            <div class="month">${this._monthYear}</div>
+            <div class="month">${this._headerText}</div>
           </td>
           <td class="clickable button" @click="${this._today}">
             <button class="today">Today</button>


### PR DESCRIPTION
Updates:
- Show the start and end of the week date text as the header for the carousel
- Fix setting of date picked to always be formatted with FORMAT_YEAR_MONTH_DAY
- Make first day of week always be Monday in the carousel